### PR TITLE
feat: Add dts bundle size tests

### DIFF
--- a/packages/azure-mock/src/index.test.ts
+++ b/packages/azure-mock/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("azure-mock", () => {
@@ -11,5 +12,13 @@ describe("azure-mock", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 36.55 KB (37429 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 36.55 KB (37429 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 42.49 KB (43506 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 42.49 KB (43506 bytes)"`);
   });
 });

--- a/packages/configuration/src/index.test.ts
+++ b/packages/configuration/src/index.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { getCrossPlatformSize } from "./getCrossPlatformSize";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("@esposter/configuration", () => {
@@ -12,5 +13,13 @@ describe("@esposter/configuration", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 3.64 KB (3725 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 3.64 KB (3725 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 1.43 KB (1466 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 1.43 KB (1466 bytes)"`);
   });
 });

--- a/packages/db-mock/src/index.test.ts
+++ b/packages/db-mock/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("@esposter/db-mock", () => {
@@ -11,5 +12,12 @@ describe("@esposter/db-mock", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 0.87 KB (886 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 0.87 KB (886 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows) expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 0.26 KB (262 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 0.26 KB (262 bytes)"`);
   });
 });

--- a/packages/db-schema/src/index.test.ts
+++ b/packages/db-schema/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("@esposter/db-schema", () => {
@@ -11,5 +12,13 @@ describe("@esposter/db-schema", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 64.59 KB (66142 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 64.59 KB (66142 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 3632.85 KB (3720037 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 3632.85 KB (3720037 bytes)"`);
   });
 });

--- a/packages/db/src/index.test.ts
+++ b/packages/db/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("@esposter/db", () => {
@@ -12,5 +13,13 @@ describe("@esposter/db", () => {
     if (isWindows)
       expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 1094.68 KB (1120952 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 1094.68 KB (1120952 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 167.53 KB (171548 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 167.53 KB (171548 bytes)"`);
   });
 });

--- a/packages/infra/src/index.test.ts
+++ b/packages/infra/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("@esposter/infra", () => {
@@ -11,5 +12,13 @@ describe("@esposter/infra", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 123.46 KB (126419 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 123.46 KB (126419 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 21.33 KB (21839 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 21.33 KB (21839 bytes)"`);
   });
 });

--- a/packages/parse-tmx/src/index.test.ts
+++ b/packages/parse-tmx/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("parse-tmx", () => {
@@ -11,5 +12,13 @@ describe("parse-tmx", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 769.59 KB (788057 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 769.59 KB (788057 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 12.25 KB (12545 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 12.25 KB (12545 bytes)"`);
   });
 });

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("@esposter/shared", () => {
@@ -11,5 +12,13 @@ describe("@esposter/shared", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 383.91 KB (393119 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 383.91 KB (393119 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 109.98 KB (112623 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 109.98 KB (112623 bytes)"`);
   });
 });

--- a/packages/vue-phaserjs/src/index.test.ts
+++ b/packages/vue-phaserjs/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("vue-phaserjs", () => {
@@ -11,5 +12,13 @@ describe("vue-phaserjs", () => {
 
     if (isWindows) expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 33.95 KB (34762 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 33.95 KB (34762 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 10.46 KB (10712 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 10.46 KB (10712 bytes)"`);
   });
 });

--- a/packages/xml2js/src/index.test.ts
+++ b/packages/xml2js/src/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const distFile = resolve(import.meta.dirname, "../dist/index.js");
+const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 const isWindows = process.platform === "win32";
 
 describe("@esposter/xml2js", () => {
@@ -12,5 +13,13 @@ describe("@esposter/xml2js", () => {
     if (isWindows)
       expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 1117.27 KB (1144087 bytes)"`);
     else expect(getCrossPlatformSize(distFile)).toMatchInlineSnapshot(`"index.js: 1117.27 KB (1144087 bytes)"`);
+  });
+
+  test("types size", () => {
+    expect.hasAssertions();
+
+    if (isWindows)
+      expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 35.81 KB (36669 bytes)"`);
+    else expect(getCrossPlatformSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 35.81 KB (36669 bytes)"`);
   });
 });


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what this PR does. -->

Fixes # <!-- issue number, if applicable -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📦 Dependency update
- [ ] 🔧 Chore / config

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Tests added or updated where applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added TypeScript declaration file size validation tests across 10 packages (`azure-mock`, `configuration`, `db-mock`, `db-schema`, `db`, `infra`, `parse-tmx`, `shared`, `vue-phaserjs`, and `xml2js`) with platform-specific snapshot assertions for Windows and non-Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->