### PR TITLE
fix: add sanitize message html

### DIFF
--- a/features/esbabbler/v7.md
+++ b/features/esbabbler/v7.md
@@ -192,12 +192,12 @@ Threads exist as a right-drawer view over replies. v7 should make them more disc
 
 - [ ] Store per-room `lastMentionRowKey` / `mentionCount` locally first; only add server state if cross-device counts become necessary.
 - [ ] Add "Jump to next mention" in the message list.
-- [ ] Highlight messages that mention the current user or one of their roles.
+- [x] Highlight messages that mention the current user or one of their roles.
 
 ### Message actions
 
-- [ ] Add "Copy Message Link" now that jump-to-message is reliable.
-- [ ] Add "Mark Unread From Here" by setting `usersToRooms.lastMessageAt` to the selected message timestamp.
+- [x] Add "Copy Message Link" now that jump-to-message is reliable.
+- [x] Add "Mark Unread From Here" by setting `usersToRooms.lastMessageAt` to the selected message timestamp.
 - [ ] Add "Remind Me" backed by scheduled jobs.
 
 Deferred:

--- a/packages/app/app/services/sanitizeHtml/sanitizeMessageHtml.test.ts
+++ b/packages/app/app/services/sanitizeHtml/sanitizeMessageHtml.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+import { sanitizeMessageHtml } from "@/services/sanitizeHtml/sanitizeMessageHtml";
+import {
+  getMentions,
+  MENTION_ID_ATTRIBUTE,
+  MENTION_ITEM_TYPE_ATTRIBUTE,
+  MENTION_TYPE,
+  MENTION_TYPE_ATTRIBUTE,
+  MentionType,
+  takeOne,
+} from "@esposter/shared";
+import { describe, expect, test } from "vitest";
+
+describe(sanitizeMessageHtml, () => {
+  test("preserves role mention metadata", () => {
+    expect.hasAssertions();
+
+    const roleId = crypto.randomUUID();
+    const html = `<span ${MENTION_TYPE_ATTRIBUTE}="${MENTION_TYPE}" ${MENTION_ID_ATTRIBUTE}="${roleId}" ${MENTION_ITEM_TYPE_ATTRIBUTE}="${MentionType.Role}"></span>`;
+    const result = sanitizeMessageHtml(html);
+    const mention = takeOne(getMentions(result));
+
+    expect(mention.getAttribute(MENTION_ID_ATTRIBUTE)).toStrictEqual(roleId);
+    expect(mention.getAttribute(MENTION_ITEM_TYPE_ATTRIBUTE)).toStrictEqual(MentionType.Role);
+    expect(mention.getAttribute(MENTION_TYPE_ATTRIBUTE)).toStrictEqual(MENTION_TYPE);
+  });
+});

--- a/packages/app/app/services/sanitizeHtml/sanitizeMessageHtml.ts
+++ b/packages/app/app/services/sanitizeHtml/sanitizeMessageHtml.ts
@@ -1,5 +1,10 @@
 import { sanitizeHtml } from "@/services/sanitizeHtml/sanitizeHtml";
-import { MENTION_ID_ATTRIBUTE, MENTION_LABEL_ATTRIBUTE, MENTION_TYPE_ATTRIBUTE } from "@esposter/shared";
+import {
+  MENTION_ID_ATTRIBUTE,
+  MENTION_ITEM_TYPE_ATTRIBUTE,
+  MENTION_LABEL_ATTRIBUTE,
+  MENTION_TYPE_ATTRIBUTE,
+} from "@esposter/shared";
 
 export const sanitizeMessageHtml = (html: string) =>
   sanitizeHtml(html, {
@@ -7,7 +12,14 @@ export const sanitizeMessageHtml = (html: string) =>
       a: ["href", "rel", "target"],
       code: ["class"],
       pre: ["class"],
-      span: ["class", MENTION_ID_ATTRIBUTE, MENTION_LABEL_ATTRIBUTE, MENTION_TYPE_ATTRIBUTE, "style"],
+      span: [
+        "class",
+        MENTION_ID_ATTRIBUTE,
+        MENTION_ITEM_TYPE_ATTRIBUTE,
+        MENTION_LABEL_ATTRIBUTE,
+        MENTION_TYPE_ATTRIBUTE,
+        "style",
+      ],
     },
     allowedStyles: {
       span: {


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what this PR does. -->

Fixes # <!-- issue number, if applicable -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📦 Dependency update
- [ ] 🔧 Chore / config

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Tests added or updated where applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v7 product roadmap reflecting the completion of two features: highlighting when users or their assigned roles are mentioned in messages, and the ability to copy message links.

* **Improvements**
  * Enhanced message processing to properly preserve mention metadata attributes during sanitization, ensuring role information is retained in messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->