### PR TITLE
chore(vscode): move oxc.path.node to gitignored workspace, tidy configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,13 @@
+# Dependencies
+node_modules
+
+# Pnpm artifacts
+.pnpm-store
+
 # Build Artifacts
 **/src/index.ts
 **/src/components/index.ts
 **/public/docs
-
-# Testing
-coverage
-.vitest-reports
-vitest.config.*.timestamp*
-
-# Local db
-*.db
-*.db-journal
-
-# Tiled
-*.tiled-session
 
 # Nuxt
 .output
@@ -24,28 +18,35 @@ vitest.config.*.timestamp*
 dist
 nuxt-build.cpuprofile
 
-# Dependencies
-node_modules
-
 # Typescript build info
 *.tsbuildinfo
 
-# Logs
-logs
-*.log
-
-# Misc
-.DS_Store
-.fleet
-.idea
+# Testing
+coverage
+.vitest-reports
+vitest.config.*.timestamp*
 
 # Local env files
 .env
 .env.*
 !.env.example
 
+# Local db
+*.db
+*.db-journal
+
+# Logs
+logs
+*.log
+
+# Tiled
+*.tiled-session
+
+# VSCode local workspace
+*.code-workspace
+
 # Claude
 scheduled_tasks.lock
 
-# Pnpm artifacts
-.pnpm-store
+# OS
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,8 @@
   },
   "javascript.updateImportsOnFileMove.enabled": "always",
   "oxc.enable": true,
-  "oxc.path.node": "${env:FNM_DIR}/aliases/default/node.exe",
+  // oxc.path.node lives in the gitignored Esposter.code-workspace (machine-specific fnm path).
+  // Reason: oxc cannot expand ${env:}/~ yet — https://github.com/oxc-project/oxc-vscode/issues/249
   "search.followSymlinks": false,
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.tsserver.maxTsServerMemory": 16384,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
       "command": "pnpm prune --prod",
       "label": "pnpm prune (functions)",
       "options": {
-        "cwd": "${workspaceFolder}/packages\\azure-functions"
+        "cwd": "${workspaceFolder}/packages/azure-functions"
       },
       "type": "shell"
     }


### PR DESCRIPTION
- oxc cannot expand ${env:}/~ (oxc-vscode#249), so the machine-specific fnm node path lives in gitignored Esposter.code-workspace
- ignore *.code-workspace; reorder .gitignore by relevance, drop unused .fleet/.idea
- fix mixed-slash cwd in tasks.json

## Description

<!-- A clear and concise description of what this PR does. -->

Fixes # <!-- issue number, if applicable -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📦 Dependency update
- [ ] 🔧 Chore / config

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Tests added or updated where applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized ignore rules to better cover dependencies, build artifacts, test output, local workspace files, and logs.
  * Added support for pnpm-related files and workspace-specific settings while keeping key lock files ignored.
  * Updated editor/task configuration for smoother local development, including clearer workspace guidance and a path formatting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->