### PR TITLE
fix: nested runs

### DIFF
--- a/packages/virrun/src/index.test.ts
+++ b/packages/virrun/src/index.test.ts
@@ -8,11 +8,11 @@ const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 describe("virrun", () => {
   test("bundle size", () => {
     expect.hasAssertions();
-    expect(getFileSize(distFile)).toMatchInlineSnapshot(`"index.js: 8.08 KB (8269 bytes)"`);
+    expect(getFileSize(distFile)).toMatchInlineSnapshot(`"index.js: 7.95 KB (8136 bytes)"`);
   });
 
   test("types size", () => {
     expect.hasAssertions();
-    expect(getFileSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 141.46 KB (144854 bytes)"`);
+    expect(getFileSize(distDtsFile)).toMatchInlineSnapshot(`"index.d.ts: 141.48 KB (144879 bytes)"`);
   });
 });

--- a/packages/virrun/src/services/configuration/resolveBackend.test.ts
+++ b/packages/virrun/src/services/configuration/resolveBackend.test.ts
@@ -1,11 +1,16 @@
 import { BackendType } from "@/models/virrun/BackendType";
 import { resolveBackend } from "@/services/configuration/resolveBackend";
 import { isOsBackendSupported } from "@/services/exec/os/isOsBackendSupported";
+import { VIRRUN_ENV_KEY } from "@/services/exec/util/constants";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock(import("@/services/exec/os/isOsBackendSupported"));
 
 describe(resolveBackend, () => {
+  // Pass an explicit empty env so the suite is hermetic: `pnpm test` runs under `virrun -- vitest`, so the real
+  // Process env already carries the VIRRUN signal the nesting guard reads.
+  const env: NodeJS.ProcessEnv = {};
+
   beforeEach(() => {
     // Default to a supported host; the degrade tests flip this so backend decisions stay host-independent.
     vi.mocked(isOsBackendSupported).mockReturnValue(true);
@@ -14,13 +19,13 @@ describe(resolveBackend, () => {
   test("defaults to auto when there is no config", () => {
     expect.hasAssertions();
 
-    expect(resolveBackend(undefined)).toBe(BackendType.Auto);
+    expect(resolveBackend(undefined, env)).toBe(BackendType.Auto);
   });
 
   test("runs the configured backend", () => {
     expect.hasAssertions();
 
-    expect(resolveBackend({ backend: BackendType.Os })).toBe(BackendType.Os);
+    expect(resolveBackend({ backend: BackendType.Os }, env)).toBe(BackendType.Os);
   });
 
   test("degrades an os backend to native when the host lacks bubblewrap support", () => {
@@ -28,7 +33,7 @@ describe(resolveBackend, () => {
 
     vi.mocked(isOsBackendSupported).mockReturnValue(false);
 
-    expect(resolveBackend({ backend: BackendType.Os })).toBe(BackendType.Native);
+    expect(resolveBackend({ backend: BackendType.Os }, env)).toBe(BackendType.Native);
   });
 
   test("leaves a non-os backend untouched on an unsupported host", () => {
@@ -36,6 +41,12 @@ describe(resolveBackend, () => {
 
     vi.mocked(isOsBackendSupported).mockReturnValue(false);
 
-    expect(resolveBackend({ backend: BackendType.Vfs })).toBe(BackendType.Vfs);
+    expect(resolveBackend({ backend: BackendType.Vfs }, env)).toBe(BackendType.Vfs);
+  });
+
+  test("degrades to native when nested inside another virrun sandbox to avoid writing the read-only cache", () => {
+    expect.hasAssertions();
+
+    expect(resolveBackend({ backend: BackendType.Os }, { [VIRRUN_ENV_KEY]: "true" })).toBe(BackendType.Native);
   });
 });

--- a/packages/virrun/src/services/configuration/resolveBackend.ts
+++ b/packages/virrun/src/services/configuration/resolveBackend.ts
@@ -1,11 +1,22 @@
 import type { VirrunConfiguration } from "@/models/virrun/VirrunConfiguration";
 
 import { BackendType } from "@/models/virrun/BackendType";
+import { isVirrunEnabled } from "@/services/configuration/isVirrunEnabled";
 import { isOsBackendSupported } from "@/services/exec/os/isOsBackendSupported";
+import process from "node:process";
 // No config defaults to Auto (native today); an `os` backend on a host without bubblewrap degrades to Native so
-// Adoption never errors the build (worst case "no speedup", never "broken").
-export const resolveBackend = (configuration: undefined | VirrunConfiguration): BackendType => {
-  if (configuration === undefined) return BackendType.Auto;
+// Adoption never errors the build (worst case "no speedup", never "broken"). A nested run — one already inside a
+// Virrun sandbox, so the injected `VIRRUN` signal is set — degrades to Native unconditionally: the outer sandbox
+// Already isolates the command, and an inner os backend would try to write its snapshot/persist overlay layers into
+// The now read-only `~/.virrun` (the outer `--ro-bind / /`), failing with EROFS. Running the inner command in-place
+// Instead lets its writes land in the outer RAM overlay. So a script that itself shells out to virrun (e.g. the root
+// `typecheck` running `virrun -- tsgo`) still works when the whole script is wrapped in another `virrun -- …`.
+export const resolveBackend = (
+  configuration: undefined | VirrunConfiguration,
+  env: NodeJS.ProcessEnv = process.env,
+): BackendType => {
+  if (isVirrunEnabled(env)) return BackendType.Native;
+  else if (configuration === undefined) return BackendType.Auto;
   else if (configuration.backend === BackendType.Os && !isOsBackendSupported()) return BackendType.Native;
   else return configuration.backend;
 };


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what this PR does. -->

Fixes # <!-- issue number, if applicable -->

## Type of change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📦 Dependency update
- [ ] 🔧 Chore / config

## Checklist

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Tests added or updated where applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend selection so Virrun now falls back to the native backend when it is already running inside another Virrun sandbox, avoiding cache write issues.
  * Preserved existing fallback behavior for unsupported OS-based backends and default backend selection.
  * Updated build size expectations in tests to match the current output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->