### PR TITLE
fix: repair main lint after #997

### DIFF
--- a/packages/app/app/composables/message/user/settings/useMicrophoneLevel.ts
+++ b/packages/app/app/composables/message/user/settings/useMicrophoneLevel.ts
@@ -37,7 +37,7 @@ export const useMicrophoneLevel = () => {
     await getResultAsync(startStream).match(
       (stream) => {
         if (!stream) return;
-        // getUserMedia cannot be cancelled, so the scope can dispose while it is still pending.
+        // A dispose can land while getUserMedia is still pending, and it cannot be cancelled.
         // UseUserMedia's own dispose then no-ops (its stream ref is still empty) and assigns the live
         // Stream afterwards, leaving the mic hot with nothing left to tear it down - so stop it here.
         else if (isDisposed) {


### PR DESCRIPTION
`#997` merged at 13:50, a few minutes before the lint fix landed on develop at 14:23, so `main` took the broken commit and not its repair. Main CI is currently failing:

- `9be58fe0d` (the #997 merge) — **failure**
- `df07b3520` (before it) — success

The only difference is one comment. `capitalized-comments` treats each `//` line as its own comment, and the line opening with `getUserMedia` starts lowercase, so oxlint fails the whole Lint job.

This PR carries the single commit `8975cac57`, which rewords that line to start with a capital without mangling the API name. Verified locally: `oxlint --disable-nested-config` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VacmrxSGVzSnKUhq6Li5Pk