### PR TITLE
Shard coverage 16-way, drop stale CodSpeed docs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
     # ubuntu-26.04, not ubuntu-latest: the virrun os-backend suites need bubblewrap >= 0.10.0 (RAM overlay) and
     # 24.04 ships 0.9.0 — on the older image the differential tests self-gate via describe.skipIf and the
     # correctness gate silently disappears.
@@ -88,14 +88,14 @@ jobs:
 
       - name: 📦 Setup Packages
         uses: ./.github/actions/setup-packages
-      # `--shard=i/8` runs a distinct 1/8th of ALL test files (every package + scripts, via the root
+      # `--shard=i/n` runs a distinct slice of ALL test files (every package + scripts, via the root
       # Vitest `projects` config) on this runner; `--reporter=blob` serialises this shard's results and
-      # Coverage data (vitest writes the per-shard `.vitest-reports/blob-i-8.json`) for the merge job.
+      # Coverage data (vitest writes the per-shard `.vitest-reports/blob-i-n.json`) for the merge job.
       # `--reporter=blob` serialises this shard's results + coverage for the merge job. We pair it with
       # `--reporter=default` so failing tests / unhandled errors are also printed to the console — the
       # blob reporter alone writes only the file and prints nothing, hiding why a shard exits non-zero.
       - name: 🧪 Test
-        run: pnpm exec vitest run --coverage --reporter=default --reporter=blob --shard=${{ matrix.shard }}/8
+        run: pnpm exec vitest run --coverage --reporter=default --reporter=blob --shard=${{ matrix.shard }}/${{ strategy.job-total }}
 
       - name: 📤 Upload blob report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status][badge-ci]][url-ci]
 [![Repository Score][badge-score]][url-score]
-[![CodSpeed Badge][badge-codspeed]][url-codspeed]
 [![Apache-2.0 licensed][badge-license]][url-license]
 
 ## Table of Contents
@@ -356,6 +355,4 @@ This project is licensed under the [Apache-2.0 license](https://github.com/Espos
 [url-license]: https://github.com/Esposter/Esposter/blob/main/LICENSE
 [badge-score]: https://img.shields.io/badge/score-93%2F100-33c854
 [url-score]: https://github.com/Esposter/Esposter/blob/main/SCORE.md
-[badge-codspeed]: https://img.shields.io/endpoint?url=https://app.codspeed.io//badge.json
-[url-codspeed]: https://app.codspeed.io//Esposter/Esposter?utm_source=badge
 [url-npm]: https://www.npmjs.com/package/Esposter/v/latest

--- a/SCORE.md
+++ b/SCORE.md
@@ -71,7 +71,7 @@ UnoCSS `presetAttributify` + `presetWind4` project-wide: static styles as elemen
 
 Nine workflows: CI, Bench, Release (tags), Pulumi (infra preview on PRs), Delete Merged Branch, Claude warmup, a reusable build, and two Azure Functions deployments (develop → dev slot, main → prod slot).
 
-CI builds every non-app package once via the reusable `build-packages` workflow, which every downstream job (`build`, `build-docs`, `coverage`, `format`, `lint`, `typecheck`) gates on. Its `actions/cache` entry is keyed by content hash and shared repo-wide, so a CI build gives Bench a cache hit for free, and vice versa — the common app-only commit skips the build entirely. Tests run through one root `vitest.config.ts` `projects` config, so coverage runs as an 8-way `--shard` matrix with `--reporter=blob`, feeding a dependent `coverage-merge` job that recombines the blobs into one artifact.
+CI builds every non-app package once via the reusable `build-packages` workflow, which every downstream job (`build`, `build-docs`, `coverage`, `format`, `lint`, `typecheck`) gates on. Its `actions/cache` entry is keyed by content hash and shared repo-wide, so a CI build gives Bench a cache hit for free, and vice versa — the common app-only commit skips the build entirely. Tests run through one root `vitest.config.ts` `projects` config, so coverage runs as a `--shard` matrix with `--reporter=blob`, feeding a dependent `coverage-merge` job that recombines the blobs into one artifact.
 
 Security hardening throughout: every third-party action is SHA-pinned, `persist-credentials: false` on all checkouts, and explicit least-privilege `permissions:`.
 

--- a/packages/app/content/docs/architecture/monorepo-tooling.md
+++ b/packages/app/content/docs/architecture/monorepo-tooling.md
@@ -75,13 +75,13 @@ flowchart LR
   BP --> L[lint]
   BP --> T[typecheck]
   BP --> D[build documentation]
-  BP --> C["coverage (×8 shards)"] --> M[merge coverage]
+  BP --> C["coverage (sharded)"] --> M[merge coverage]
   BP --> A[build app]
 ```
 
 Tests run through a single root `vitest.config.ts` with a `projects: ["packages/*", <scripts>]` config — every package (the app as a Nuxt project via `defineVitestProject`, the rest by their own configs) plus the root `scripts/` suite is one project in one vitest run. So `coverage`/`test` are `vitest run` at the root, not a `pnpm -r` fan-out.
 
-`coverage` runs as an 8-way matrix: `pnpm exec vitest run --coverage --reporter=blob --shard=i/8` splits _all_ test files across runners (each shard runs a distinct eighth and writes the collision-safe `.vitest-reports/blob-i-8.json`, which carries that shard's coverage data). A dependent `merge coverage` job downloads all eight blobs and runs `pnpm exec vitest run --merge-reports --coverage` to recombine them into one unified coverage report — this re-emits the report only, it does not re-run tests. CI invokes `vitest` via `pnpm exec` (not `pnpm coverage -- …`) because pnpm does not reliably forward post-`--` args to the script here, which silently dropped `--shard`/`--reporter`.
+`coverage` runs as a matrix over `.github/workflows/CI.yaml`'s `matrix.shard`: `pnpm exec vitest run --coverage --reporter=blob --shard=i/n` splits _all_ test files across runners (each shard runs a distinct slice and writes the collision-safe `.vitest-reports/blob-i-n.json`, which carries that shard's coverage data). A dependent `merge coverage` job downloads every blob and runs `pnpm exec vitest run --merge-reports --coverage` to recombine them into one unified coverage report — this re-emits the report only, it does not re-run tests. CI invokes `vitest` via `pnpm exec` (not `pnpm coverage -- …`) because pnpm does not reliably forward post-`--` args to the script here, which silently dropped `--shard`/`--reporter`.
 
 Sharding shortens the coverage work itself but not total CI time, which is gated by `lint`; it is kept for faster test-failure feedback and so every suite (previously `vue-phaserjs` and the `scripts/` tests were skipped by the coverage fan-out) is covered. There are no coverage thresholds, so a partial per-shard report cannot false-fail. Matrix shards are isolated runners with no shared filesystem, so each repeats checkout + install + `setup-packages`; the package _build_ is not repeated (it is downloaded as an artifact), so the per-shard cost is setup only.
 

--- a/packages/infra/src/github/rulesets/developMainStatusChecks.ts
+++ b/packages/infra/src/github/rulesets/developMainStatusChecks.ts
@@ -3,7 +3,7 @@ import { repository } from "@/github/repository";
 import * as github from "@pulumi/github";
 // Must match the length of the `coverage` job's `matrix.shard` in .github/workflows/CI.yaml — each shard
 // Publishes its own `Coverage (n)` check context, and only contexts listed here are enforced.
-const coverageShardCount = 8;
+const coverageShardCount = 16;
 // Required status checks live in their own ruleset so that Renovate is not a bypass actor for them.
 // Renovate bypasses the pull request requirement in developMainProtection so branch automerge can push
 // Straight to the base branch, but its updates must still land green. Bypass is granted per ruleset and

--- a/packages/infra/src/index.test.ts
+++ b/packages/infra/src/index.test.ts
@@ -8,7 +8,7 @@ const distDtsFile = resolve(import.meta.dirname, "../dist/index.d.ts");
 describe("@esposter/infra", () => {
   test("bundle size", () => {
     expect.hasAssertions();
-    expect(getFileSize(distFile)).toMatchInlineSnapshot(`"index.js: 112.45 KB (115151 bytes)"`);
+    expect(getFileSize(distFile)).toMatchInlineSnapshot(`"index.js: 112.45 KB (115152 bytes)"`);
   });
 
   test("types size", () => {

--- a/packages/shared-node/README.md
+++ b/packages/shared-node/README.md
@@ -32,7 +32,7 @@ The benchmark reporting toolkit consumed by the repo's `vitest bench` runs (see 
 
 - **Node-only**: depends on Node built-ins (`fs`, `os`) — must not be bundled into the browser app.
 - Depends on `@esposter/shared` for shared types and utilities.
-- Wired into `vitest bench` via `BenchmarkMarkdownReporter`; the CodSpeed dashboard layer reads the emitted artifacts.
+- Wired into `vitest bench` via `BenchmarkMarkdownReporter`; the emitted artifacts are committed and diffed offline as the speed gate.
 
 ### Commands
 

--- a/packages/virrun/README.md
+++ b/packages/virrun/README.md
@@ -55,7 +55,7 @@ We highly recommend you take a look at the [documentation](https://esposter.com/
 
 - 🚀 [Getting Started][doc-getting-started] — prerequisites, CLI, programmatic API, package scripts.
 - 🤖 [CI][doc-ci] — the two gates (differential correctness + speed) and the CI snapshot cache.
-- 🏎️ [Speed Harness][doc-speed-harness] — benchmarking conventions, committed `*.bench.md`, CodSpeed.
+- 🏎️ [Speed Harness][doc-speed-harness] — benchmarking conventions, committed `*.bench.md`, the CI smoke signal.
 
 Design docs live in [`packages/app/content/docs/virrun`](https://github.com/Esposter/Esposter/tree/main/packages/app/content/docs/virrun) — start with the [architecture overview](https://github.com/Esposter/Esposter/blob/main/packages/app/content/docs/virrun/architecture.md) and the [execution backends page](https://github.com/Esposter/Esposter/blob/main/packages/app/content/docs/virrun/execution-backends.md).
 

--- a/packages/virrun/readme/speed-harness.md
+++ b/packages/virrun/readme/speed-harness.md
@@ -15,13 +15,10 @@ Regenerate before committing and diff the multipliers — this is the offline re
 - A workload whose numbers genuinely differ by host (the `os` backend runs `os/linux` natively and `os/wsl` bridged from win32) is named `*.platform.bench.ts`. The reporter then writes per-platform artifacts (`Foo.platform.bench.<platform>.{json,md}`, keyed by `process.platform`) so a win32 run and a linux run each update only their own committed file instead of clobbering each other.
 - Plain `*.bench.ts` stays single-artifact and cross-platform.
 
-## CodSpeed dashboard
+## CI smoke signal
 
-The 🏎️ Bench workflow instruments the same colocated `*.bench.ts` files (no bench rewrite) via CodSpeed and uploads to the hosted dashboard for PR regression comments + flamegraphs:
+The 🏎️ Bench workflow runs the same colocated `*.bench.ts` files as a plain sharded `vitest bench --run` on every push. It is a smoke signal only — that every bench still executes — not a speed gate: shared-runner wall-clock is too noisy for a pass/fail bar, so regression detection stays with the committed `*.bench.md` diffed offline. It is its own workflow rather than a 🏗️ CI job, so it never blocks a merge.
 
-- **simulation** — CPU/cache simulation + flamegraphs, hardware-independent, free on `ubuntu-latest` (sharded 8×). This is the CI speed signal.
-- **walltime / memory** — real elapsed time + heap allocations on CodSpeed's bare-metal runners, run unsharded.
-
-The reporter self-disables under `CODSPEED_ENV`, so instrumented CI runs don't rewrite the committed `*.bench.md`.
+The reporter does rewrite `*.bench.md` beside each bench on the runner, but that is ephemeral disk and nothing commits it, so the tracked artifacts are untouched.
 
 See [CI](https://github.com/Esposter/Esposter/blob/main/packages/virrun/readme/ci.md) for how the speed gate is enforced.


### PR DESCRIPTION
## Summary

- **Coverage matrix 8 → 16 shards.** `matrix.shard` is now `[1..16]` and the run line derives its total from `${{ strategy.job-total }}`, so the matrix list is the only place the count lives. `coverageShardCount` in the Pulumi ruleset is bumped to match — each shard publishes its own `Coverage (n)` required check context.
- **Docs stop restating the count.** `monorepo-tooling.md` and `SCORE.md` describe the matrix over `CI.yaml`'s `matrix.shard` (`--shard=i/n`, `blob-i-n.json`) rather than hardcoding a number that rots on the next change.
- **Stale CodSpeed content removed.** CodSpeed was dropped when its runs exceeded the free tier, but the readmes still documented the dashboard as the CI speed signal — including a `CODSPEED_ENV` reporter self-disable that nothing in the code reads. The speed harness page now describes what 🏎️ Bench actually is (a plain sharded `vitest bench --run` smoke signal in its own workflow), and the root README loses the badge, whose shields endpoint was malformed (`app.codspeed.io//badge.json`). `virrun/readme/ci.md` keeps the line recording that CodSpeed was removed and why.

## Test plan

- [ ] 🏗️ CI reports `Coverage (1)`…`Coverage (16)`, all green, and `Merge Coverage` recombines all sixteen blobs into one report
- [x] `pnpm exec vitest run packages/app/content/docs.test.ts` — 138 passed (mermaid parse validation for the edited diagram)
- [x] `pnpm format:check` clean on every touched file
- [ ] `pulumi up` applies the widened required-check list before this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Expanded coverage testing from 8 to 16 parallel shards.
  * Updated status checks and reporting to support dynamically sized shard matrices.

* **Documentation**
  * Updated CI coverage and benchmarking documentation to reflect sharded workflows.
  * Replaced CodSpeed references with the current CI-based benchmark and smoke-signal process.
  * Removed the CodSpeed badge from the README.

* **Maintenance**
  * Updated bundle-size test expectations following a minor size increase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->