### PR TITLE
fix(routing): keep the breadcrumb trail a history entry can hold

### DIFF
--- a/.claude/skills/routing/SKILL.md
+++ b/.claude/skills/routing/SKILL.md
@@ -61,6 +61,12 @@ Decide by what the value **is**, not by what is reachable:
 
   Its lifetime already matches: per entry, kept across a reload, restored on back/forward, gone with the entry.
 
+  **Everything in that object is structured-cloned, so none of it may be reactive state.** A `ref`'s array or a
+  store's object reaches the serializer as a Proxy, which it rejects outright — and the `DataCloneError` is thrown
+  inside the `afterEach` hook, so it rejects the navigation that was being recorded rather than merely losing the
+  value. Hand the entry a plain snapshot, and make that the returned contract of the pure function above rather
+  than a spread at the call site.
+
 - **What the visitor prefers** (a collapsed rail, a theme) → **`localStorage`** through the `LocalStorageKey` registry — it outlives the tab and belongs to the person.
 
 The middle case is the one that gets mis-filed. Putting "how I got here" in the URL mints a second address for one page (worse for sharing, bookmarks and analytics, and editable by anyone who types); putting it in storage makes it outlive the journey, so a tab restored later claims a path nobody walked.

--- a/packages/app/app/services/shared/getNextNavigationTrail.test.ts
+++ b/packages/app/app/services/shared/getNextNavigationTrail.test.ts
@@ -2,6 +2,7 @@ import { NavigationTrailPage } from "@/models/shared/NavigationTrailPage";
 import { getNextNavigationTrail } from "@/services/shared/getNextNavigationTrail";
 import { RoutePath } from "@esposter/shared";
 import { describe, expect, test } from "vitest";
+import { reactive } from "vue";
 
 describe(getNextNavigationTrail, () => {
   const resourcePath = RoutePath.Resource("id");
@@ -65,6 +66,20 @@ describe(getNextNavigationTrail, () => {
       getNextNavigationTrail(resourcePath, otherResourcePath, [NavigationTrailPage.Resources, NavigationTrailPage.All]),
     ).toStrictEqual([NavigationTrailPage.Resources, NavigationTrailPage.All]);
     expect(getNextNavigationTrail(bladePath, otherResourcePath, [NavigationTrailPage.All])).toStrictEqual([
+      NavigationTrailPage.All,
+    ]);
+  });
+
+  // The plugin writes what comes back onto the history entry, and the browser structured-clones it. The trail it
+  // Passes in is the store's own reactive array, so a branch that returned it untouched put a proxy in front of
+  // The serializer — a DataCloneError that rejected the very navigation the trail was being recorded for
+  test("returns a trail the history entry can hold", () => {
+    expect.hasAssertions();
+
+    const trail = reactive([NavigationTrailPage.Resources, NavigationTrailPage.All]);
+
+    expect(structuredClone(getNextNavigationTrail(resourcePath, otherResourcePath, trail))).toStrictEqual([
+      NavigationTrailPage.Resources,
       NavigationTrailPage.All,
     ]);
   });

--- a/packages/app/app/services/shared/getNextNavigationTrail.ts
+++ b/packages/app/app/services/shared/getNextNavigationTrail.ts
@@ -14,7 +14,10 @@ const getPage = (path: string) => NAVIGATION_TRAIL_PAGE_ENTRIES.find(([, crumb])
 // Moving around inside one page apart from leaving it for another
 const getPageKey = (path: string) => path.split("/").slice(0, 3).join("/");
 // Where a navigation leaves the trail — the whole model, as one pure function, so it is testable without a
-// Browser and the plugin only has to decide when to ask. See /docs/platform/breadcrumb-trail
+// Browser and the plugin only has to decide when to ask. Every branch returns a fresh plain array, never the one
+// It was handed: the caller writes the result onto the history entry, which the browser structured-clones, and
+// The trail it passes in is the store's own reactive array — a proxy the serializer rejects outright.
+// See /docs/platform/breadcrumb-trail
 export const getNextNavigationTrail = (
   fromPath: string,
   toPath: string,
@@ -36,5 +39,5 @@ export const getNextNavigationTrail = (
   // Re-entered with different filters — and one arriving from outside the area carries the empty trail that
   // Leaving it left behind, which is exactly what a direct arrival is
   if (fromPage && getPageKey(fromPath) !== getPageKey(toPath)) return [...trail, fromPage];
-  return trail;
+  return [...trail];
 };


### PR DESCRIPTION
## Summary

Navigating inside the resource explorer threw `DataCloneError: Failed to execute 'replaceState' on 'History': [object Object] could not be cloned`, and the navigation it was thrown from rejected with it. Refreshing the same url was fine — an entry that already carries a trail takes the early return and never writes.

`getNextNavigationTrail` returned its own `trail` argument on the carry-through branch: another blade, another resource from the list rail, a filter change, and the query-only `router.replace` an edit dialog does on open and close. The plugin hands it `navigationTrailStore.trail`, which is the store ref's array and therefore a reactive Proxy, and it went straight back out into `history.replaceState`. The structured clone algorithm rejects a Proxy outright, inside a `router.afterEach` hook — so the whole navigation rejected rather than merely losing the trail.

Every branch now returns a fresh plain array, which is the contract the caller needs; the other three branches already allocated one.

## Changes

- `getNextNavigationTrail` returns a plain copy on the carry-through branch, and says why in its own comment.
- Regression test: the returned trail survives `structuredClone` when the function is handed a `reactive` trail. It fails with `DataCloneError` without the fix.
- `routing` skill: nothing reactive may go on a history entry, and why the failure takes the navigation with it.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test --run` in `packages/app` — 370 files, 2052 tests passing
- [ ] Manual: drill into a resource, switch blades and open/close an item's edit dialog — no `DataCloneError` in the console, breadcrumb still truncates on a crumb click and survives back/forward and a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation trail handling when navigating with reactive data.
  * Prevented navigation failures caused by non-serializable history state.
  * Navigation history now consistently uses safe, plain data that can be restored and serialized reliably.

* **Documentation**
  * Added guidance for ensuring navigation state is safe for browser history and related integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->