### PR TITLE
Repair the ApexCharts v7 fallout, drop what v7 stopped bundling free, keep a PWA's theme

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -133,7 +133,16 @@
     "import/no-unassigned-import": [
       "error",
       {
-        "allow": ["**/*.css", "**/*.d.ts", "**/*.i18n", "crossws", "nuxt/schema", "phaser", "vue-phaserjs"]
+        "allow": [
+          "**/*.css",
+          "**/*.d.ts",
+          "**/*.i18n",
+          "apexcharts/features/*",
+          "crossws",
+          "nuxt/schema",
+          "phaser",
+          "vue-phaserjs"
+        ]
       }
     ],
     "import/prefer-default-export": "off",

--- a/packages/app/app/components/Nuxt/Theme.vue
+++ b/packages/app/app/components/Nuxt/Theme.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { ThemeMode } from "@/models/vuetify/ThemeMode";
-import { THEME_COOKIE_NAME } from "@/services/vuetify/constants";
+import { THEME_COOKIE_NAME, THEME_COOKIE_OPTIONS } from "@/services/vuetify/constants";
 
 defineSlots<{ default: () => VNode }>();
 
 const theme = useVTheme();
-const themeCookie = useCookie(THEME_COOKIE_NAME, { default: () => ThemeMode.system });
+const themeCookie = useCookie(THEME_COOKIE_NAME, { ...THEME_COOKIE_OPTIONS, default: () => ThemeMode.system });
 const { $ssrClientHints } = useNuxtApp();
 const preferredDark = usePreferredDark();
 // Vuetify resolves ThemeMode.system through a matchMedia ref that exists only in the browser, so handing it

--- a/packages/app/app/components/Styled/ApexChart.vue
+++ b/packages/app/app/components/Styled/ApexChart.vue
@@ -3,9 +3,6 @@ import type ApexCharts from "apexcharts";
 import type { VueApexChartsComponentProps } from "vue3-apexcharts";
 
 import { defu } from "defu";
-// v7 ships the renderer opt-in, so `chart.renderer` below is inert without it — and inert silently, because an
-// Unregistered feature is a config key nothing reads rather than an error
-import "apexcharts/features/renderer-canvas";
 import VueApexCharts from "vue3-apexcharts";
 
 type ApexChartProps = Pick<VueApexChartsComponentProps, "options" | "series" | "type">;
@@ -13,16 +10,9 @@ type ApexChartProps = Pick<VueApexChartsComponentProps, "options" | "series" | "
 const { options = {}, series, type } = defineProps<ApexChartProps>();
 const isDark = useIsDark();
 const chart = useTemplateRef<{ chart?: ApexCharts }>("chart");
-// Two things every chart in the app gets, whatever it is drawing:
-//
 // Vuetify owns the theme, so the mode is pinned instead of letting ApexCharts auto-resolve it. The mode flip
-// Also re-renders the chart, which re-reads the "--apx-*" design tokens (globals.scss).
-//
-// The series layer paints to canvas once a chart carries more points than the renderer's threshold, while the
-// Axes, tooltips, annotations and exports stay SVG — so a dense chart costs nothing anywhere else.
-const themedOptions = computed(() =>
-  defu({ chart: { renderer: "auto" }, theme: { mode: isDark.value ? "dark" : "light" } } as const, options),
-);
+// Also re-renders the chart, which re-reads the "--apx-*" design tokens (globals.scss)
+const themedOptions = computed(() => defu({ theme: { mode: isDark.value ? "dark" : "light" } } as const, options));
 // The chart instance, for the view state a caller captures and restores off it. Handed out as a getter rather
 // Than the ref, because it exists only between the component's mounted and unmounted events
 defineExpose({ getChart: () => chart.value?.chart });

--- a/packages/app/app/components/Styled/ApexChart.vue
+++ b/packages/app/app/components/Styled/ApexChart.vue
@@ -3,6 +3,9 @@ import type ApexCharts from "apexcharts";
 import type { VueApexChartsComponentProps } from "vue3-apexcharts";
 
 import { defu } from "defu";
+// v7 ships the renderer opt-in, so `chart.renderer` below is inert without it — and inert silently, because an
+// Unregistered feature is a config key nothing reads rather than an error
+import "apexcharts/features/renderer-canvas";
 import VueApexCharts from "vue3-apexcharts";
 
 type ApexChartProps = Pick<VueApexChartsComponentProps, "options" | "series" | "type">;

--- a/packages/app/app/composables/dashboard/useVisualPerspective.ts
+++ b/packages/app/app/composables/dashboard/useVisualPerspective.ts
@@ -1,5 +1,7 @@
 import type ApexCharts from "apexcharts";
 
+// Registers the feature that puts `chart.perspectives` on the instance; opt-in since v7
+import "apexcharts/features/perspectives";
 import { DASHBOARD_VIEW_QUERY_KEY } from "@/services/dashboard/chart/constants";
 import { parseViewEntry } from "@/services/dashboard/chart/parseViewEntry";
 import { setViewEntryToken } from "@/services/dashboard/chart/setViewEntryToken";

--- a/packages/app/app/composables/vuetify/useToggleTheme.ts
+++ b/packages/app/app/composables/vuetify/useToggleTheme.ts
@@ -1,8 +1,8 @@
-import { THEME_COOKIE_NAME } from "@/services/vuetify/constants";
+import { THEME_COOKIE_NAME, THEME_COOKIE_OPTIONS } from "@/services/vuetify/constants";
 
 export const useToggleTheme = () => {
   const theme = useVTheme();
-  const themeCookie = useCookie(THEME_COOKIE_NAME);
+  const themeCookie = useCookie(THEME_COOKIE_NAME, THEME_COOKIE_OPTIONS);
   return async (event: PointerEvent) => {
     theme.setTransitionOrigin(event);
     await theme.cycle();

--- a/packages/app/app/services/dashboard/chart/constants.ts
+++ b/packages/app/app/services/dashboard/chart/constants.ts
@@ -1,7 +1,8 @@
 import type { ApexOptions } from "apexcharts";
 
 // Each option below names a feature v7 ships opt-in, so the registration travels with the option that needs it:
-// Importing this file is what makes these four exist, and using them without it silently configures nothing
+// Importing this file is what makes these four exist. Setting one of them without its import configures nothing
+// And says so on the console — which is the whole warning, on a surface nobody watches on a phone
 import "apexcharts/features/context-menu";
 import "apexcharts/features/history";
 import "apexcharts/features/ink";

--- a/packages/app/app/services/dashboard/chart/constants.ts
+++ b/packages/app/app/services/dashboard/chart/constants.ts
@@ -1,5 +1,12 @@
 import type { ApexOptions } from "apexcharts";
 
+// Each option below names a feature v7 ships opt-in, so the registration travels with the option that needs it:
+// Importing this file is what makes these four exist, and using them without it silently configures nothing
+import "apexcharts/features/context-menu";
+import "apexcharts/features/history";
+import "apexcharts/features/ink";
+import "apexcharts/features/measure";
+
 // What turns a dashboard tile from a picture into something a reader can interrogate without leaving the page:
 // Undo/redo over every zoom, series toggle and annotation edit; a right-click menu that acts at the point under
 // The cursor; a ruler for the change between two points; and draggable, editable annotations. They sit in one

--- a/packages/app/app/services/dashboard/chart/getVisualLinkChartOptions.ts
+++ b/packages/app/app/services/dashboard/chart/getVisualLinkChartOptions.ts
@@ -1,6 +1,8 @@
 import type { Visual } from "#shared/models/dashboard/data/Visual";
 import type { ApexOptions } from "apexcharts";
 
+// Registers the linked-views feature the `link` option below is read by; opt-in since v7
+import "apexcharts/features/link";
 import { ID_SEPARATOR } from "@esposter/shared";
 
 // Brushing a range only says something where there is an x axis to brush. A pie, a radial, a radar and a treemap

--- a/packages/app/app/services/vuetify/constants.ts
+++ b/packages/app/app/services/vuetify/constants.ts
@@ -1,2 +1,10 @@
+import { dayjs } from "#shared/services/dayjs";
+
 export const THEME_COOKIE_NAME = "theme";
+// Written with an explicit lifetime, because a cookie with none is a session cookie — and an installed PWA ends
+// Its session whenever the OS evicts the standalone window, which it does routinely. The chosen theme then
+// Vanished and the app fell back to the system preference, so the setting looked like it reset at random.
+// Shared by the reader and the writer: the options given at each `useCookie` call are what serialise the write,
+// So a lifetime on one call site alone is a lifetime the other silently drops
+export const THEME_COOKIE_OPTIONS = { maxAge: dayjs.duration(1, "year").asSeconds() };
 export const DISABLED_OPACITY = 0.38;

--- a/packages/app/content/docs/platform/dashboard-chart-interaction.md
+++ b/packages/app/content/docs/platform/dashboard-chart-interaction.md
@@ -11,7 +11,6 @@ A dashboard tile is something a reader interrogates, not only a picture they loo
 
 ```mermaid
 flowchart TD
-  SHARED["StyledApexChart<br/>every chart in the app"] -->|"renderer: auto"| CANVAS["dense series paint to canvas<br/>axes · tooltips · exports stay SVG"]
   VIS["Dashboard visual only"] --> INT["VISUAL_INTERACTION_CHART_OPTIONS<br/>history · contextMenu · measure · ink"]
   INT --> WM["each is watermarked<br/>editor and published view alike"]
   VIS --> LINK["getVisualLinkChartOptions<br/>group = dataset reference + x column"]
@@ -19,10 +18,6 @@ flowchart TD
   VIS --> PERS["useVisualPerspective<br/>?view=visualId~token"]
   PERS -->|"on mounted"| APPLY["zoom · hidden series · selection restored"]
 ```
-
-Everywhere a chart renders (`StyledApexChart`):
-
-- **Canvas rendering** — `chart.renderer: "auto"`. The series layer paints to canvas past the point threshold; axes, tooltips, annotations and exports stay SVG. Nothing else changes shape, which is why it is on for every chart rather than opted into per surface. It buys nothing at today's dataset row cap — it is what would let that cap rise.
 
 On dashboard visuals only:
 
@@ -41,7 +36,6 @@ So the `import "apexcharts/features/…"` sits beside the option that needs it r
 
 | Registration                                         | Declared by                                                   |
 | ---------------------------------------------------- | ------------------------------------------------------------- |
-| `features/renderer-canvas`                           | `StyledApexChart` — `chart.renderer`                          |
 | `features/history`, `context-menu`, `ink`, `measure` | `services/dashboard/chart/constants.ts`                       |
 | `features/link`                                      | `getVisualLinkChartOptions` — `chart.link` and the group      |
 | `features/perspectives`                              | `useVisualPerspective` — `chart.perspectives` on the instance |
@@ -59,6 +53,8 @@ The consequence for editing this page's features is that they move as a set: the
 ## What is deliberately off
 
 - **Crossfilter FILTER mode** — the mode where clicking a bucket re-aggregates every linked chart. It asks each chart for one `dimension` and one `reduce`, which is a single derived series; a visual here declares `query.series[]` and can carry several. Expressing a multi-series visual through it is not possible, and running it alongside `computeDatasetVisualPropsData` would put two aggregation engines in the same tile. HIGHLIGHT mode, above, needs no aggregation change and is what ships.
+- **Canvas rendering** (`chart.renderer`, `features/renderer-canvas`) — on while v6 bundled it for free, and removed when v7 priced it. It is a 10.9 KB gzipped module on every surface that draws a chart, and it is unreachable: `rendererThreshold` defaults to 8000 points, a dataset read caps at 1000 rows, and a visual aggregates those rows into categories, so a series cannot approach the threshold. Add the module back when the row cap rises, not before.
+- **The lean core bundle** (`apexcharts/core` plus per-type registration) — measured rather than assumed. The sixteen chart-type entries this app needs come to 285 KB gzipped against the full bundle's 219 KB, because the entries overlap heavily: every line-family type carries the same 16.7 KB and every pie-family type the same 14.5 KB. Lean pays for a surface drawing two or three types and costs about 66 KB here.
 - **OS-aware themes** (`theme.follow`) — Vuetify owns the theme, and `StyledApexChart` pins the mode to it deliberately. Following the OS instead would fight the app's own switch.
 - **Streaming** (`chart.streaming`) — bounds memory for `appendData` on a live feed. Datasets are read and refreshed, never appended to; there is no feed to bound.
 - **Scrollytelling** (`chart.storyboard`) — pairs prose sections with saved chart views. Nothing in the app puts a chart inside prose.

--- a/packages/app/content/docs/platform/dashboard-chart-interaction.md
+++ b/packages/app/content/docs/platform/dashboard-chart-interaction.md
@@ -33,6 +33,21 @@ On dashboard visuals only:
 - **Linked highlighting** — `getVisualLinkChartOptions` groups visuals **by the dataset reference and the `query.xColumn` they categorise it by**, not by the dashboard they sit on. Both halves are load-bearing: the reference is what makes two charts describe the same rows, and the x column is what makes one chart's axis mean the same thing as another's. One sheet grouped by month and the same sheet grouped by region share every row and no axis at all, so linking them would dim each other's marks by coincidence of position. A visual with no binding renders demo data and joins no group, and a chart type with no x axis to brush (pie, donut, polar area, radar, radial bar, treemap) is left out.
 - **Shareable view state** — `useVisualPerspective` captures a visual's zoom window, hidden series and selection into a token and puts it in the url as `?view=<visualId>~<token>`. The parameter repeats, so a link carries the state of every chart its sender touched, and a token that no longer decodes opens the dashboard unfiltered rather than failing.
 
+## Every feature here is registered where it is configured
+
+ApexCharts v7 ships these as **opt-in modules**: the default bundle registers only the baseline set, and a feature that has not been imported is not present. The failure mode is the dangerous kind — an unregistered feature makes its option a config key nothing reads, so the chart renders perfectly and does nothing new, with no error and no warning anywhere.
+
+So the `import "apexcharts/features/…"` sits beside the option that needs it rather than in one setup file:
+
+| Registration                                         | Declared by                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------- |
+| `features/renderer-canvas`                           | `StyledApexChart` — `chart.renderer`                          |
+| `features/history`, `context-menu`, `ink`, `measure` | `services/dashboard/chart/constants.ts`                       |
+| `features/link`                                      | `getVisualLinkChartOptions` — `chart.link` and the group      |
+| `features/perspectives`                              | `useVisualPerspective` — `chart.perspectives` on the instance |
+
+Importing the module that builds an option is what makes that option real, so a new consumer of any of them cannot pick up the config without the feature. Adding an option from a module not listed above means adding its import next to it — the v7 upgrade turned every one of these off silently, which is why they are colocated rather than gathered.
+
 ## The watermark
 
 `history`, `contextMenu`, `measure`, `ink`, linked highlighting and perspectives are gated by the vendor. They work as documented above, and every chart carrying one renders a repeating "APEXCHARTS" watermark over it — on the editor and on the published `/view/Dashboard/[id]` page alike.

--- a/packages/app/content/docs/platform/dashboard-chart-interaction.md
+++ b/packages/app/content/docs/platform/dashboard-chart-interaction.md
@@ -30,7 +30,9 @@ On dashboard visuals only:
 
 ## Every feature here is registered where it is configured
 
-ApexCharts v7 ships these as **opt-in modules**: the default bundle registers only the baseline set, and a feature that has not been imported is not present. The failure mode is the dangerous kind — an unregistered feature makes its option a config key nothing reads, so the chart renders perfectly and does nothing new, with no error and no warning anywhere.
+ApexCharts v7 ships these as **opt-in modules**: the default bundle registers only the baseline set, and a feature that has not been imported is not present. Its option then configures nothing and the chart renders perfectly without it — nothing throws, and nothing on the page changes.
+
+How loudly that is announced depends on the feature, and the difference matters when you are diagnosing one. `chart.history`, `chart.contextMenu`, `chart.measure`, `chart.ink` and `chart.link` each `console.warn` on render naming the exact import to add. **`perspectives` does not** — the library's own configuration calls it passive, so `chart.perspectives` is simply absent from the instance and a capture returns nothing. A console warning is also a weak signal for the surfaces here: a dashboard read on a phone, or a published `/view/Dashboard/[id]` page, has nobody watching a console.
 
 So the `import "apexcharts/features/…"` sits beside the option that needs it rather than in one setup file:
 
@@ -40,7 +42,7 @@ So the `import "apexcharts/features/…"` sits beside the option that needs it r
 | `features/link`                                      | `getVisualLinkChartOptions` — `chart.link` and the group      |
 | `features/perspectives`                              | `useVisualPerspective` — `chart.perspectives` on the instance |
 
-Importing the module that builds an option is what makes that option real, so a new consumer of any of them cannot pick up the config without the feature. Adding an option from a module not listed above means adding its import next to it — the v7 upgrade turned every one of these off silently, which is why they are colocated rather than gathered.
+Importing the module that builds an option is what makes that option real, so a new consumer of any of them cannot pick up the config without the feature. Adding an option from a module not listed above means adding its import next to it — the v7 upgrade turned every one of these off at once, which is why they are colocated rather than gathered.
 
 ## The watermark
 


### PR DESCRIPTION
## ApexCharts v7 fallout

The Renovate bump (#1098) moved nine features out of the default bundle. Seven are ones this app configures, so all seven went inert — and inert **silently**: an unregistered feature makes its option a config key nothing reads, so the charts kept rendering with no error and no warning.

Verified against the installed 7.0.0 bundle: the auto-registered set is now `annotations`, `drilldown`, `exports`, `keyboardNavigation`, `legend`, `morphTypeChange`, `osThemeWatcher`, `weave`, and `registerRenderer` does not appear at all.

| Feature | Option that stopped working |
| --- | --- |
| `history` | undo/redo on dashboard visuals |
| `context-menu` | point-scoped right-click menu |
| `measure` | the ruler |
| `ink` | annotation authoring |
| `link` | linked highlighting across a dataset's visuals |
| `perspectives` | `?view=` shareable view state |

Each `import "apexcharts/features/…"` is placed beside the code that declares its option rather than in one setup file, so importing the module that builds an option is what makes that option real. Confirmed these attach to the right class: `apexcharts.esm.js` itself imports `apexcharts/core`, and every feature module does too, so there is one shared instance rather than two.

The other two breaking changes need nothing: `plotOptions.bar.borderRadiusWhenStacked` is unused, and nothing sets `dataLabels.animate`, so labels now ride to their new position on a data change — which is what that default is for.

## Lean pass — measured, not assumed

**Canvas rendering is removed.** `chart.renderer: "auto"` was worth setting while v6 bundled the renderer for free. v7 prices it at 10.9 KB gzipped on every surface that draws a chart, and it cannot fire: `rendererThreshold` defaults to **8000 points**, a dataset read caps at **1000 rows**, and a visual aggregates those rows into categories, so a series never approaches the threshold. Unreachable code paying rent. The docs page records the condition for bringing it back.

**The lean core bundle is deliberately not adopted**, and this is the measurement rather than a hunch:

| | gzipped |
| --- | --- |
| Full bundle (`apexcharts.esm.js`) | 219.3 KB |
| The 16 chart-type entries this app needs, registered individually | 285.0 KB |

The per-type entries overlap heavily instead of composing — every line-family type carries the same 16.7 KB, every pie-family type the same 14.5 KB. Lean pays for a surface drawing two or three types; here it would cost about 66 KB. Recorded on the docs page so nobody re-derives it.

## PWA theme reset

Separately reported: the theme sometimes resets in the installed mobile PWA.

The cookie was written with no options at all, so no `Max-Age` — a session cookie. An installed PWA ends its session whenever the OS evicts the standalone window, which mobile does routinely; the cookie went with it and the app fell back to the system preference. That is the "sometimes", and why it looked unrelated to anything the user did. Ruled out a stale precached shell — there is no `navigateFallback` configured.

The lifetime is shared by the reader and the writer, because the options passed at each `useCookie` call are what serialise that call's write.

## Lint

The six registration imports exist for their side effect and export nothing, so `import/no-unassigned-import` rejected them. Allowed by pattern in `.oxlintrc.json` rather than six suppression comments, so the next registration is covered.

## Not done

**Trellis** (`trellis: { by: column }`) — small multiples split by a column, the most interesting thing in v7 for this dashboard and a clean fit for `DatasetQuery`. It is a new capability with a form surface, not part of repairing a bump.

**`markers.largeDatasetThreshold`** — opt-in marker batching; little to win at the 1000-row cap.

## Verification

Typecheck, root lint (oxlint + eslint + per-package), and the dashboard/chart/vuetify/docs test paths pass on 7.0.0. Not visually verified — driving the app is banned in this repo, so the registrations are confirmed from the bundle's own `registerFeatures` calls and the module graph rather than from a rendered chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzAP3NKQ2JtRyg93N4GDf3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced chart interaction capabilities, including perspectives, linked views, context menus, history, ink, and measurement tools.
  * Theme preferences are now retained for up to one year.

* **Bug Fixes**
  * Charts now respect the configured renderer instead of forcing automatic rendering.

* **Documentation**
  * Updated chart interaction documentation to describe opt-in features and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->